### PR TITLE
Get recent actions working with our custom admin site

### DIFF
--- a/jet/__init__.py
+++ b/jet/__init__.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.6.dev12'
+VERSION = '1.0.6.dev13'

--- a/jet/dashboard/templates/jet.dashboard/modules/recent_actions.html
+++ b/jet/dashboard/templates/jet.dashboard/modules/recent_actions.html
@@ -30,10 +30,10 @@
                         <span>{% trans 'Unknown content' %}</span>
                     {% endif %}
 
-                    {% if entry.is_deletion or not entry.get_admin_url %}
+                    {% if entry.is_deletion or not entry|tt_admin_url %}
                         <span class="tooltip" title="{{ entry|format_change_message }}">{{ entry.object_repr }}</span>
                     {% else %}
-                        <a title="{{ entry|format_change_message }}" class="tooltip" href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+                        <a title="{{ entry|format_change_message }}" class="tooltip" href="{{ entry|tt_admin_url }}">{{ entry.object_repr }}</a>
                     {% endif %}
                 </div>
             </li>

--- a/jet/dashboard/templatetags/jet_dashboard_tags.py
+++ b/jet/dashboard/templatetags/jet_dashboard_tags.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 from django import template
+from django.contrib.admin.utils import quote
+from django.urls import NoReverseMatch, reverse
 from jet.dashboard.utils import get_current_dashboard
 
 register = template.Library()
@@ -21,3 +23,18 @@ def format_change_message(log_entry):
         return log_entry.get_change_message()
     else:
         return log_entry.change_message
+
+
+@register.filter
+def tt_admin_url(item):
+    """
+    This is a sad hack so the recent actions work with our custom 'ttadmin'
+    site instead of default.
+    """
+    if item.content_type and item.object_id:
+        url_name = 'ttadmin:%s_%s_change' % (item.content_type.app_label, item.content_type.model)
+        try:
+            return reverse(url_name, args=(quote(item.object_id),))
+        except NoReverseMatch:
+            pass
+    return None


### PR DESCRIPTION
#### What's this PR do?
Fixes "Recent actions" modules around the Jet dashboard.

#### Why are we doing this? How does it help us?
We knew it was a little broken, but didn't realize it was pretending to work but sending people to the wrong place. This was worse than broken, so now it's being fixed.

#### How should this be manually tested?
- First set up this branch on the main TT repo-- you should be able to do that by running `make` on master, then `pip install -e git+https://github.com/mailbackwards/django-jet@fix-recent-actions#egg=jet`.
- Go to the admin dashboard and see that your "Recent actions" show up. Confirm that a variety of types of models -- stories, articles, media files, users, etc. -- all link to their respective admin pages. Confirm that these pages are going to `/admin/` urls, rather than `/cms_admin/` urls.

If this works for others, I'll build it into the pypi and update setup accordingly.

#### Have automated tests been added?
No

#### Has this been tested on mobile?
N/A

#### Are there performance implications?
Shouldn't be.

#### What are the relevant tickets?
https://3.basecamp.com/3098728/buckets/736178/todos/1081735122

#### How should this change be communicated to end users?
Tell editors+Ryan that "Recent actions" should be working again.

#### Next steps?
N/A

#### Smells?
More Jet customization. This one feels a little more like a Django smell than a Jet one to be honest. I thought about putting the template filter in our core repo rather than this Jet one, but it would then be even more cross-dependent than this is. This should just fail silently if `ttadmin` doesn't exist, so NBD.

#### TODOs:
N/A

#### Has the relevant documentation/wiki been updated?
No

#### Technical debt note
More